### PR TITLE
Fix empty key for unsaved field data

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -50,7 +50,7 @@ class Block extends FieldsBuilder
 
         foreach (array_keys($data) as $field) {
             if (preg_match("/^field_{$group}/", $field)) {
-                $data[$key = ltrim($field, "field_{$group}_")] = $data[$field];
+                $data[preg_replace("/field_{$group}_/", '', $field)] = $data[$field];
             }
         }
 


### PR DESCRIPTION
Before there were 500 errors when fields needed to save. When fields save, the array of data that is fed to the template to render a preview has different keys than the data that is used when Gutenberg renders from saved data. This was a little way around that which intercepts and fixes the keys. This fix uses `preg_replace()` instead of `ltrim()` since either the latter never worked for this task or it’s simply stopped working for it. 🤔 Anyway, it's fixed.